### PR TITLE
Update component-menu-drawer.css

### DIFF
--- a/assets/component-menu-drawer.css
+++ b/assets/component-menu-drawer.css
@@ -159,7 +159,7 @@ menu-drawer > details[open] > summary::before {
 .menu-drawer__menu-item--active,
 .menu-drawer__menu-item:focus,
 .menu-drawer__close-button:focus,
-.menu-drawer__menu-item:hover,
+.menu-drawer__menu-item:show,
 .menu-drawer__close-button:hover {
   color: rgb(var(--color-foreground));
   background-color: rgba(var(--color-foreground), 0.04);


### PR DESCRIPTION
submenu is broken on mobile. default to show submenu instead of hover